### PR TITLE
chore: make two functions private to prevent clashes

### DIFF
--- a/Calcify/Basic.lean
+++ b/Calcify/Basic.lean
@@ -11,7 +11,7 @@ open Lean.Meta.Tactic.TryThis (delabToRefinableSyntax addSuggestion)
 -- copied from std4/Std/Lean/Meta/Basic.lean
 /-- Solve a goal by synthesizing an instance. -/
 -- FIXME: probably can just be `g.inferInstance` once leanprover/lean4#2054 is fixed
-def Lean.MVarId.synthInstance (g : MVarId) : MetaM Unit := do
+private def Lean.MVarId.synthInstance (g : MVarId) : MetaM Unit := do
   g.assign (← Lean.Meta.synthInstance (← g.getType))
 
 -- NB: Pattern matching on terms using `mkAppN` is not good practice, as

--- a/Calcify/Basic.lean
+++ b/Calcify/Basic.lean
@@ -439,7 +439,7 @@ example (x n : Nat) (P : Nat → Prop) (hP : P n): P (if 0 + (1 * x) = 0 then x 
   exact hP
 
 @[congr]
-theorem List.map_congr {f g : α → β} : ∀ {l : List α}, (∀ x ∈ l, f x = g x) → map f l = map g l
+private theorem List.map_congr {f g : α → β} : ∀ {l : List α}, (∀ x ∈ l, f x = g x) → map f l = map g l
   | [], _ => rfl
   | a :: l, h => by
     let ⟨h₁, h₂⟩ := forall_mem_cons.1 h


### PR DESCRIPTION
These would clash with the versions from Batteries/Mathlib otherwise, preventing the tactic to be used with them.